### PR TITLE
Adds in the ability to tag files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ Tokens are shown with their line number and starting index.
 This is useful when debugging the language itself or for some more unusual shenanigans.
 Defaults to returning the syntax tree as a text file, by specifiying the `--json` flag will instead return them as a JSON file.
 
+## Tagging lines for localisation
+
+```bash
+$ ysc tag [--output-directory <output>] <input1.yarn> <input2.yarn> ...
+```
+
+Tags the input Yarn files with line ID hashtag for localisation.
+Uses the line tagging code from YarnSpinner core, this means by default lines will be tagged following the rules of tagging lines from the core.
+If `--output-directory` is not set will default to overriding the files in place.
+
 ## License
 
 `ysc` is available under the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,37 @@ This flag is not set by default meaning each line of dialogue will halt the stor
 
 **NOTE:** Custom functions are not supported and encountering one will cause the story to be aborted.
 
+## Upgrading Scripts
+
+```bash
+$ ysc upgrade [--upgrade-type <1>] <input1.yarn> <input2.yarn> ...
+```
+
+`ysc` will upgrade the `yarn` files from one version of Yarn to another.
+By specifying the `--upgrade-type` option you can configure from what version, to which version, of Yarn to convert.
+Defaults to `1`, or upgrading a yarn v1 file to a yarn v2 file.
+
+## Printing the Syntax Tree
+
+```bash
+ysc print-tree [--output-directory <output>] [--json] <input1.yarn> <input2.yarn> ...
+```
+
+Prints a human readable form of the dialogue syntax tree of the input Yarn files.
+This is useful when debugging the language itself or for some more unusual shenanigans.
+Defaults to returning the syntax tree as a text file, by specifiying the `--json` flag can instead return them as a JSON file.
+
+## Printing the Parser Tokens
+
+```bash
+ysc print-tokens [--output-directory <output>] [--json] <input1.yarn> <input2.yarn> ...
+```
+
+Prints a list of all parser tokens from the included Yarn files.
+Tokens are shown with their line number and starting index.
+This is useful when debugging the language itself or for some more unusual shenanigans.
+Defaults to returning the syntax tree as a text file, by specifiying the `--json` flag can instead return them as a JSON file.
+
 ## License
 
 `ysc` is available under the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -41,23 +41,23 @@ Defaults to `1`, or upgrading a yarn v1 file to a yarn v2 file.
 ## Printing the Syntax Tree
 
 ```bash
-ysc print-tree [--output-directory <output>] [--json] <input1.yarn> <input2.yarn> ...
+$ ysc print-tree [--output-directory <output>] [--json] <input1.yarn> <input2.yarn> ...
 ```
 
 Prints a human readable form of the dialogue syntax tree of the input Yarn files.
 This is useful when debugging the language itself or for some more unusual shenanigans.
-Defaults to returning the syntax tree as a text file, by specifiying the `--json` flag can instead return them as a JSON file.
+Defaults to returning the syntax tree as a text file, by specifiying the `--json` flag will instead return them as a JSON file.
 
 ## Printing the Parser Tokens
 
 ```bash
-ysc print-tokens [--output-directory <output>] [--json] <input1.yarn> <input2.yarn> ...
+$ ysc print-tokens [--output-directory <output>] [--json] <input1.yarn> <input2.yarn> ...
 ```
 
 Prints a list of all parser tokens from the included Yarn files.
 Tokens are shown with their line number and starting index.
 This is useful when debugging the language itself or for some more unusual shenanigans.
-Defaults to returning the syntax tree as a text file, by specifiying the `--json` flag can instead return them as a JSON file.
+Defaults to returning the syntax tree as a text file, by specifiying the `--json` flag will instead return them as a JSON file.
 
 ## License
 

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -3,13 +3,11 @@
     using System;
     using System.Collections.Generic;
     using System.CommandLine;
-    using System.CommandLine.Invocation;
     using System.IO;
     using System.Linq;
     using System.Text;
     using System.Text.Json;
     using System.Text.Json.Serialization;
-    using Yarn;
     using Yarn.Compiler;
     using Yarn.Compiler.Upgrader;
 


### PR DESCRIPTION
This adds in a new command that lets you tag files, uses the built in YS core tagger.
Also updates the readme for the new tag command and the other commands that weren't in the readme.
Fixes #1 