### PR TITLE
Add a relative path option which allows input files to be compiled as relative paths rather than absolute ones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ You can install `ysc` by downloading the [most recent release](https://github.co
 ## Compiling Scripts
 
 ```bash
-$ ysc compile [--merge] [--output-directory <output>] <input1.yarn> <input2.yarn> ...
+$ ysc compile [--merge] [--output-directory <output>] [--use-input-relative-paths] <input1.yarn> <input2.yarn> ...
 ```
 
 `ysc` will compile all of the `.yarn` files you provide, and generate two files for each: a `.yarnc` file containing the compiled file, and a `.csv` containing the extracted string table.
 
 If you specify the `--merge` option, a single `output.yarnc` and `output.csv` file will be created.
+
+If you specify the `--use-input-relative-paths` option, output files will use relative paths for yarn files rather than absolute paths.
 
 ## Running Scripts
 
@@ -98,4 +100,3 @@ If `--output-directory` is not set will default to overriding the files in place
 ## Contributing
 
 See the [Contributing guide](CONTRIBUTING.md) for developer documentation.
-


### PR DESCRIPTION
This PR adds a console command option that allows input paths to be used as relative paths rather than absolute paths.

When absolute paths were used, node names included the entire path of the node which caused conflicts between different contributors that had different local workspace setups.

Thanks all for such a great project! :)