### PR TITLE
Fix metadata exports. Properly filters out only line tags and exports all others.

### DIFF
--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -437,8 +437,9 @@
                 csv.NextRecord();
                 foreach (var pair in compiledResults.StringTable)
                 {
-                    // if there are less than two items we have only the lineID itself in the metadata
-                    if (pair.Value.metadata.Length < 2)
+                    // filter out line: metadata
+                    var metadata = pair.Value.metadata.Where(metadata => !metadata.StartsWith("line:")).ToList();
+                    if (metadata.Count == 0)
                     {
                         continue;
                     }
@@ -446,10 +447,11 @@
                     csv.WriteField(pair.Key);
                     csv.WriteField(pair.Value.nodeName);
                     csv.WriteField(pair.Value.lineNumber);
-                    foreach (var record in pair.Value.metadata)
+                    foreach (var record in metadata)
                     {
                         csv.WriteField(record);
                     }
+
                     csv.NextRecord();
                 }
 


### PR DESCRIPTION
Previously, the console would filter any line that had 1 item.

This would not properly account for lines that had no `line:` tag.

This PR changes the behaviour so that the command will filter out line tags and then check if there are any remaining ones.

Additionally, on lines with additional metadata, `line:` metadata will no longer be exported.