### PR TITLE
Added string extraction for VO feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Fetch all commits
       run: git fetch --unshallow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- New subcommand `extract` allows for extraction of lines for the purpose of VO.
+
 ### Changed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If `--output-directory` is not set will default to overriding the files in place
 ## Extracting lines for recording
 
 ```bash
-$ ysc extract <input1.yarn> <input2.yarn> ... [--format csv|xlsx]
+$ ysc extract <input1.yarn> <input2.yarn> ... [--format csv|xlsx] [--columns column1 column2 ...]
 ```
 
 Creates a tables of all lines in the included Yarn files in a format intended for easier recording.
@@ -102,6 +102,12 @@ Runs of lines are collected and seperated in the table.
 Currently the table shows the character, the line, and the line ID in that order.
 Defaults to extracting the strings as a csv but this can be changed using the `--format` option.
 If the excel option is set (`--format xlsx`) then conditional highlighting will be used to colour each characters lines.
+
+If the `columns` option is set you can define a list of columns you want the output to have.
+There are three pre-defined columns (`text`, `id`, `character`) which can be used and the exporter will fill in the appropriate line details in that place.
+Any custom columns are left blank.
+If setting the columns you must include at least `text` and `id` somewhere in your for the extraction to continue.
+If `--columns` is not set it will default to using the columns `character`, `text`, `id` in that order.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -94,12 +94,13 @@ If `--output-directory` is not set will default to overriding the files in place
 ## Extracting lines for recording
 
 ```bash
-$ ysc extract <input1.yarn> <input2.yarn> ... [--format csv|xlsx] [--columns column1 column2 ...]
+$ ysc extract <input1.yarn> <input2.yarn> ... [--format csv|xlsx] [--columns <column1> <column2> ...] [--default-name <name>]
 ```
 
 Creates a tables of all lines in the included Yarn files in a format intended for easier recording.
 Runs of lines are collected and seperated in the table.
 Currently the table shows the character, the line, and the line ID in that order.
+
 Defaults to extracting the strings as a csv but this can be changed using the `--format` option.
 If the excel option is set (`--format xlsx`) then conditional highlighting will be used to colour each characters lines.
 
@@ -108,6 +109,9 @@ There are three pre-defined columns (`text`, `id`, `character`) which can be use
 Any custom columns are left blank.
 If setting the columns you must include at least `text` and `id` somewhere in your for the extraction to continue.
 If `--columns` is not set it will default to using the columns `character`, `text`, `id` in that order.
+
+If the `default-name` option is set you can define a default name for lines of dialogue that do not have a character set.
+Defaults to none if not used.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If `--output-directory` is not set will default to overriding the files in place
 ## Extracting lines for recording
 
 ```bash
-$ ysc extract <input1.yarn> <input2.yarn> ... [--format csv|xlsx] [--columns <column1> <column2> ...] [--default-name <name>]
+$ ysc extract <input1.yarn> <input2.yarn> ... [--format csv|xlsx] [--columns <column1> <column2> ...] [--default-name <name>] [--output <file>]
 ```
 
 Creates a tables of all lines in the included Yarn files in a format intended for easier recording.
@@ -112,6 +112,10 @@ If `--columns` is not set it will default to using the columns `character`, `tex
 
 If the `default-name` option is set you can define a default name for lines of dialogue that do not have a character set.
 Defaults to none if not used.
+
+If the `output` option is set you can define a file location for the extracted dialogue.
+When exporting an `xlsx` the file type of set when using `--output` *must* be `xlsx` or else the export will fail.
+Defaults to `lines` in the current directory if not set.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ Tags the input Yarn files with line ID hashtag for localisation.
 Uses the line tagging code from YarnSpinner core, this means by default lines will be tagged following the rules of tagging lines from the core.
 If `--output-directory` is not set will default to overriding the files in place.
 
+## Extracting lines for recording
+
+```bash
+$ ysc extract <input1.yarn> <input2.yarn> ... [--format csv|xlsx]
+```
+
+Creates a tables of all lines in the included Yarn files in a format intended for easier recording.
+Runs of lines are collected and seperated in the table.
+Currently the table shows the character, the line, and the line ID in that order.
+Defaults to extracting the strings as a csv but this can be changed using the `--format` option.
+If the excel option is set (`--format xlsx`) then conditional highlighting will be used to colour each characters lines.
+
 ## License
 
 `ysc` is available under the [MIT License](LICENSE.md).

--- a/src/YarnSpinner.Console/AssemblyInfo.cs
+++ b/src/YarnSpinner.Console/AssemblyInfo.cs
@@ -1,3 +1,7 @@
-﻿
+﻿using System.Reflection;
+
 // During CI builds,this file will be populated by GitVersion with version information
-// at build time.
+// at build time, and these placeholder version numbers will be replaced.
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("0.0.0+0.Branch.unknown.Sha.0000000000000000000000000000000000000000")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/src/YarnSpinner.Console/AssemblyInfo.cs
+++ b/src/YarnSpinner.Console/AssemblyInfo.cs
@@ -1,4 +1,3 @@
-﻿using System.Reflection;
-
+﻿
 // During CI builds,this file will be populated by GitVersion with version information
 // at build time.

--- a/src/YarnSpinner.Console/BasicBlockAnalysis.cs
+++ b/src/YarnSpinner.Console/BasicBlockAnalysis.cs
@@ -1,0 +1,618 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Yarn.Analysis
+{
+    /// <summary>
+    /// Contains extension methods for producing <see cref="BasicBlock"/>
+    /// objects from a Node.
+    /// </summary>
+    public static class InstructionCollectionExtensions
+    {
+        /// <summary>
+        /// Produces <see cref="BasicBlock"/> objects from a Node.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        /// <exception cref="System.InvalidOperationException"></exception>
+        public static IEnumerable<BasicBlock> GetBasicBlocks(this Node node)
+        {
+            // If we don't have any instructions, return an empty collection
+            if (node == null || node.Instructions == null || node.Instructions.Count == 0)
+            {
+                return Enumerable.Empty<BasicBlock>();
+            }
+
+            var result = new List<BasicBlock>();
+
+            var leaderIndices = new HashSet<int>
+            {
+                // The first instruction is a leader.
+                0,
+            };
+
+            foreach (var label in node.Labels)
+            {
+                // If the instruction is labelled (i.e. it is the target of a
+                // jump), it is a leader.
+                leaderIndices.Add(label.Value);
+            }
+
+            for (int i = 0; i < node.Instructions.Count; i++)
+            {
+                // Every instruction after a jump (conditional or
+                // nonconditional) is a leader.
+                switch (node.Instructions[i].Opcode)
+                {
+                    case Instruction.Types.OpCode.JumpTo:
+                    case Instruction.Types.OpCode.Jump:
+                    case Instruction.Types.OpCode.JumpIfFalse:
+                    case Instruction.Types.OpCode.Stop:
+                    case Instruction.Types.OpCode.RunNode:
+                        leaderIndices.Add(i + 1);
+                        break;
+                    default:
+                        // nothing to do
+                        break;
+                }
+            }
+
+            // Now that we know what the leaders are, run through the
+            // instructions; every time we encounter a leader, start a new basic
+            // block.
+            var currentBlockInstructions = new List<Instruction>();
+
+            int lastLeader = 0;
+
+            for (int i = 0; i < node.Instructions.Count; i++)
+            {
+                // The current instruction is a leader! If we have accumulated
+                // instructions, create a new block from them, store it, and
+                // start a new list of instructions.
+                if (leaderIndices.Contains(i))
+                {
+                    if (currentBlockInstructions.Count > 0)
+                    {
+                        var block = new BasicBlock
+                        {
+                            NodeName = node.Name,
+                            Instructions = new List<Instruction>(currentBlockInstructions),
+                            FirstInstructionIndex = lastLeader,
+                            LabelName = GetLabelNameForInstructionIndex(lastLeader),
+                        };
+                        result.Add(block);
+                    }
+
+                    lastLeader = i;
+                    currentBlockInstructions.Clear();
+                }
+
+                // Add the current instruction to our current accumulation.
+                currentBlockInstructions.Add(node.Instructions[i]);
+            }
+
+            // We've reached the end of the instruction list. If we have any
+            // accumulated instructions, create a final block here.
+            if (currentBlockInstructions.Count > 0)
+            {
+                var block = new BasicBlock
+                {
+                    NodeName = node.Name,
+                    Instructions = new List<Instruction>(currentBlockInstructions),
+                    FirstInstructionIndex = lastLeader,
+                    LabelName = GetLabelNameForInstructionIndex(lastLeader),
+                };
+                result.Add(block);
+            }
+
+            BasicBlock GetBlock(string label)
+            {
+                var index = node.Labels[label];
+
+                try
+                {
+                    return result.First(block => block.FirstInstructionIndex == index);
+                }
+                catch (System.InvalidOperationException)
+                {
+                    // nothing found
+                    throw new System.InvalidOperationException($"No block in {node.Name} starts at index {index}");
+                }
+            }
+            BasicBlock GetBlockWithIndex(int index)
+            {
+                try
+                {
+                    return result.First(block => block.FirstInstructionIndex == index);
+                }
+                catch (System.InvalidOperationException)
+                {
+                    // nothing found
+                    throw new System.InvalidOperationException($"No block in {node.Name} starts at index {index}");
+                }
+            }
+
+            // Given an instruction index, returns the name of the label for
+            // this index, or null if the instruction doesn't have a label.
+            string GetLabelNameForInstructionIndex(int index)
+            {
+                return node.Labels.FirstOrDefault(pair => pair.Value == index).Key;
+            }
+
+            // Final pass: now that we have all the blocks, go through each of
+            // them and build the links between them
+            foreach (var block in result)
+            {
+                var optionDestinations = new List<string>();
+                string currentStringAtTopOfStack = null;
+                int count = 0;
+                foreach (var instruction in block.Instructions)
+                {
+                    switch (instruction.Opcode)
+                    {
+                        case Instruction.Types.OpCode.AddOption:
+                            {
+                                // Track the destination that this instruction says
+                                // it'll jump to. It'll either be to a named label, or
+                                // to a node.
+                                var destinationNodeName = instruction.Operands.ElementAt(1);
+                                optionDestinations.Add(destinationNodeName.StringValue);
+                                break;
+                            }
+                        case Instruction.Types.OpCode.Jump:
+                            {
+                                // We're jumping to a labeled section of the same node.
+                                foreach (var destinationLabel in optionDestinations)
+                                {
+                                    var destinationBlock = GetBlock(destinationLabel);
+
+                                    block.AddDestination(destinationBlock, BasicBlock.Condition.Option);
+                                }
+                                break;
+                            }
+                        case Instruction.Types.OpCode.JumpTo:
+                            {
+                                var destinationBlock = GetBlock(instruction.Operands.ElementAt(0).StringValue);
+                                block.AddDestination(destinationBlock, BasicBlock.Condition.DirectJump);
+                                break;
+                            }
+                        case Instruction.Types.OpCode.PushString:
+                            {
+                                // The top of the stack is now a string. (This
+                                // isn't perfect, because it doesn't handle
+                                // stuff like functions, which modify the stack,
+                                // but the most common case is <<jump
+                                // NodeName>>, which is a combination of 'push
+                                // string' followed by 'run node at top of
+                                // stack')
+                                currentStringAtTopOfStack = instruction.Operands.ElementAt(0).StringValue;
+                                break;
+                            }
+                        case Instruction.Types.OpCode.PushBool:
+                        case Instruction.Types.OpCode.PushFloat:
+                        case Instruction.Types.OpCode.PushVariable:
+                            {
+                                // The top of the stack is now no longer a
+                                // string. Again, not a fully accurate
+                                // representation of what's going on, but for
+                                // the moment, we're not supporting 'jump to
+                                // expression' here.
+                                currentStringAtTopOfStack = null;
+                                break;
+                            }
+                        case Instruction.Types.OpCode.RunNode:
+                            {
+                                if (currentStringAtTopOfStack != null)
+                                {
+                                    block.AddDestination(currentStringAtTopOfStack, BasicBlock.Condition.DirectJump);
+                                }
+                                break;
+                            }
+                        case Instruction.Types.OpCode.JumpIfFalse:
+                            {
+                                var destinationLabel = instruction.Operands.ElementAt(0).StringValue;
+
+                                var destinationFalseBlock = GetBlock(destinationLabel);
+                                var destinationTrueBlock = GetBlockWithIndex(block.FirstInstructionIndex + count + 1);
+
+                                block.AddDestination(destinationFalseBlock, BasicBlock.Condition.ExpressionIsFalse);
+                                block.AddDestination(destinationTrueBlock, BasicBlock.Condition.ExpressionIsTrue);
+                                break;
+                            }
+                    }
+                    count += 1;
+                }
+
+                if (block.Destinations.Count() == 0)
+                {
+                    // We've reached the end of this block, and don't have any
+                    // destinations. If our last destination isn't 'stop', then
+                    // we'll fall through to the next node.
+                    if (block.Instructions.Last().Opcode != Instruction.Types.OpCode.Stop)
+                    {
+                        var nextBlockStartInstruction = block.FirstInstructionIndex + block.Instructions.Count();
+
+                        var destination = GetBlockWithIndex(nextBlockStartInstruction);
+                        block.AddDestination(destination, BasicBlock.Condition.Fallthrough);
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// A basic block is a run of instructions inside a Node. Basic blocks group
+    /// instructions up into segments such that execution only ever begins at
+    /// the start of a block (that is, a program never jumps into the middle of
+    /// a block), and execution only ever leaves at the end of a block.
+    /// </summary>
+    public class BasicBlock
+    {
+        /// <summary>
+        /// Gets the name of the label that this block begins at, or null if this basic block does not begin at a labelled instruction.
+        /// </summary>
+        public string LabelName { get; set; }
+
+        /// <summary>
+        /// Gets the name of the node that this block is in.
+        /// </summary>
+        public string NodeName { get; set; }
+
+        /// <summary>
+        /// Gets the index of the first instruction of the node that this block is in.
+        /// </summary>
+        public int FirstInstructionIndex { get; set; }
+
+        /// <summary>
+        /// Gets a descriptive name for the block.
+        /// </summary>
+        /// <remarks>
+        /// If this block begins at a labelled instruction, the name will be <c>[NodeName].[LabelName]</c>. Otherwise, it will be <c>[NodeName].[FirstInstructionIndex]</c>.
+        /// </remarks>
+        public string Name 
+        {
+            get 
+            {
+                if (LabelName != null) 
+                {
+                    return $"{NodeName}.{LabelName}";
+                }
+                else
+                {
+                    return $"{NodeName}.{FirstInstructionIndex}";
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the ancestors of this block - that is, blocks that may run immediately before this block.
+        /// </summary>
+        public IEnumerable<BasicBlock> Ancestors => ancestors;
+
+        /// <summary>
+        /// Gets the destinations of this block - that is, blocks or nodes that
+        /// may run immediately after this block.
+        /// </summary>
+        /// <seealso cref="Destination"/>
+        public IEnumerable<Destination> Destinations => destinations;
+
+        /// <summary>
+        /// Gets the Instructions that form this block.
+        /// </summary>
+        public IEnumerable<Instruction> Instructions { get; set; } = new List<Instruction>();
+
+        /// <summary>
+        /// Adds a new destination to this block, that points to another block.
+        /// </summary>
+        /// <param name="descendant">The new descendant node.</param>
+        /// <param name="condition">The condition under which <paramref
+        /// name="descendant"/> will be run.</param>
+        /// <exception cref="ArgumentNullException">Thrown when descendant is
+        /// <see langword="null"/>.</exception>
+        public void AddDestination(BasicBlock descendant, Condition condition)
+        {
+            if (descendant is null)
+            {
+                throw new ArgumentNullException(nameof(descendant));
+            }
+
+            destinations.Add(new Destination { Type = Destination.DestinationType.Block, Block = descendant, Condition = condition });
+            descendant.ancestors.Add(this);
+        }
+
+        /// <summary>
+        /// Adds a new destination to this block, that points to a node.
+        /// </summary>
+        /// <param name="nodeName">The name of the destination node.</param>
+        /// <param name="condition">The condition under which <paramref
+        /// name="descendant"/> will be run.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref
+        /// name="nodeName"/> is <see langword="null"/>.</exception>
+        public void AddDestination(string nodeName, Condition condition)
+        {
+            if (string.IsNullOrEmpty(nodeName))
+            {
+                throw new ArgumentException($"'{nameof(nodeName)}' cannot be null or empty.", nameof(nodeName));
+            }
+
+            destinations.Add(new Destination { Type = Destination.DestinationType.Node, NodeName = nodeName, Condition = condition });
+        }
+
+        private HashSet<BasicBlock> ancestors = new HashSet<BasicBlock>();
+
+        private HashSet<Destination> destinations = new HashSet<Destination>();
+
+        /// <summary>
+        /// A destination represents a <see cref="BasicBlock"/> or node that may
+        /// be run, following the execution of a <see cref="BasicBlock"/>.
+        /// </summary>
+        /// <remarks>
+        /// Destination objects represent links between blocks, or between
+        /// blocks and nodes.
+        /// </remarks>
+        public struct Destination
+        {
+            /// <summary>
+            /// The type of a Destination.
+            /// </summary>
+            public enum DestinationType
+            {
+                Node,
+                Block,
+            }
+
+            /// <summary>
+            /// Gets the Destination's type - whether the destination is a
+            /// block, or a node.
+            /// </summary>
+            public DestinationType Type { get; set; }
+
+            /// <summary>
+            /// The name of the node that this destination refers to.
+            /// </summary>
+            /// <remarks>This value is only valid when <see cref="Type"/> is
+            /// <see cref="DestinationType.Node"/>.</remarks>
+            public string NodeName { get; set; }
+
+            /// <summary>
+            /// The block that this destination refers to.
+            /// </summary>
+            /// <remarks>This value is only valid when <see cref="Type"/> is
+            /// <see cref="DestinationType.Block"/>.</remarks>
+            public BasicBlock Block { get; set; }
+
+            /// <summary>
+            /// The condition that causes this destination to be reached.
+            /// </summary>
+            public Condition Condition { get; set; }
+        }
+
+        /// <summary>
+        /// Gets all descendants (that is, destinations, and destinations of
+        /// those destinations, and so on), recursively.
+        /// </summary>
+        /// <remarks>
+        /// Cycles are detected and avoided.
+        /// </remarks>
+        public IEnumerable<BasicBlock> Descendants
+        {
+            get 
+            {
+                // Start with a queue of immediate children that link to blocks
+                Queue<BasicBlock> candidates = new Queue<BasicBlock>(this.Destinations.Where(d => d.Block != null).Select(d=> d.Block));
+
+                List<BasicBlock> descendants = new List<BasicBlock>();
+
+                while (candidates.Count > 0)
+                {
+                    var next = candidates.Dequeue();
+                    if (descendants.Contains(next)) 
+                    {
+                        // We've already seen this one - skip it.
+                        continue;
+                    }
+                    descendants.Add(next);
+                    foreach (var destination in next.Destinations.Where(d => d.Block != null).Select(d=> d.Block))
+                    {
+                        candidates.Enqueue(destination);
+                    }
+                }
+
+                return descendants;
+
+            }
+        }
+
+        /// <summary>
+        /// Gets all descendants (that is, destinations, and destinations of
+        /// those destinations, and so on) that have any player-visible content,
+        /// recursively.
+        /// </summary>
+        /// <remarks>
+        /// Cycles are detected and avoided.
+        /// </remarks>
+        public IEnumerable<BasicBlock> DescendantsWithPlayerVisibleContent
+        {
+            get
+            {
+                return Descendants.Where(d => d.PlayerVisibleContent.Any());
+            }
+        }
+
+        /// <summary>
+        /// The conditions under which a <see cref="Destination"/> may be
+        /// reached at the end of a BasicBlock.
+        /// </summary>
+        public enum Condition
+        {
+            /// <summary>
+            /// The Destination is reached because the preceding BasicBlock
+            /// reached the end of its execution, and the Destination's target
+            /// is the block immediately following.
+            /// </summary>
+            Fallthrough,
+
+            /// <summary>
+            /// The Destination is reached beacuse of an explicit instruction to
+            /// go to this block.
+            /// </summary>
+            DirectJump,
+
+            /// <summary>
+            /// The Destination is reached because an expression evaluated to
+            /// true.
+            /// </summary>
+            ExpressionIsTrue,
+
+            /// <summary>
+            /// The Destination is reached because an expression evaluated to
+            /// false.
+            /// </summary>
+            ExpressionIsFalse,
+
+            /// <summary>
+            /// The Destination is reached because the player made an in-game
+            /// choice to go to it.
+            /// </summary>
+            Option,
+        }
+
+        /// <summary>
+        /// An abstract class that represents some content that is shown to the
+        /// player.
+        /// </summary>
+        /// <remarks>
+        /// This class is used, rather than the runtime classes Yarn.Line or
+        /// Yarn.OptionSet, because when the program is being analysed, no
+        /// values for any substitutions are available. Instead, these classes
+        /// represent the data that is available offline.
+        /// </remarks>
+        public abstract class PlayerVisibleContentElement
+        {
+        }
+
+        /// <summary>
+        /// A line of dialogue that should be shown to the player.
+        /// </summary>
+        public class LineElement : PlayerVisibleContentElement
+        {
+            /// <summary>
+            /// The string table ID of the line that will be shown to the player.
+            /// </summary>
+            public string LineID;
+        }
+
+        /// <summary>
+        /// A collection of options that should be shown to the player.
+        /// </summary>
+        public class OptionsElement : PlayerVisibleContentElement
+        {
+            /// <summary>
+            /// Represents a single option that may be presented to the player.
+            /// </summary>
+            public struct Option
+            {
+                /// <summary>
+                /// The string table ID that will be shown to the player.
+                /// </summary>
+                public string LineID;
+
+                /// <summary>
+                /// The destination that will be run if this option is selected
+                /// by the player.
+                /// </summary>
+                /// <remarks>
+                /// This will be the name of a label, or the name of a node.
+                /// </remarks>
+                public string Destination;
+            }
+
+            /// <summary>
+            /// The collection of options that will be delivered to the player.
+            /// </summary>
+            public IEnumerable<Option> Options;
+        }
+
+        /// <summary>
+        /// A command that will be executed.
+        /// </summary>
+        public class CommandElement : PlayerVisibleContentElement
+        {
+            /// <summary>
+            /// The text of the command.
+            /// </summary>
+            public string CommandText;
+        }
+
+        /// <summary>
+        /// Gets the collection of player-visible content that will be delivered
+        /// when this block is run.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Player-visible content means lines, options and commands. When this
+        /// block is run, the entire contents of this collection will be
+        /// displayed to the player, in the same order as they appear in this
+        /// collection.
+        /// </para>
+        /// <para>
+        /// If this collection is empty, then the block contains no visible
+        /// content. This is the case for blocks that only contain logic, and do
+        /// not contain any lines, options or commands.
+        /// </para>
+        /// <example>
+        /// To tell the difference between the different kinds of content, use
+        /// the <see langword="is"/> operator to check the type of each item:
+        /// <code>
+        /// foreach (var item in block.PlayerVisibleContent) { if (item is
+        /// LineElement line) { // Do something with line } }
+        /// </code>
+        /// </example>
+        /// </remarks>
+        public IEnumerable<PlayerVisibleContentElement> PlayerVisibleContent
+        {
+            get
+            {
+                var accumulatedOptions = new List<(string LineID, string Destination)>();
+                foreach (var instruction in Instructions)
+                {
+                    switch (instruction.Opcode)
+                    {
+                        case Instruction.Types.OpCode.RunLine:
+                            yield return new LineElement
+                            {
+                                LineID = instruction.Operands[0].StringValue
+                            };
+                            break;
+
+                        case Instruction.Types.OpCode.RunCommand:
+                            yield return new CommandElement
+                            {
+                                CommandText = instruction.Operands[0].StringValue
+                            };
+                            break;
+
+                        case Instruction.Types.OpCode.AddOption:
+                            accumulatedOptions.Add((instruction.Operands[0].StringValue, instruction.Operands[1].StringValue));
+                            break;
+
+                        case Instruction.Types.OpCode.ShowOptions:
+                            yield return new OptionsElement
+                            {
+                                Options = accumulatedOptions.Select(o => new OptionsElement.Option
+                                {
+                                    Destination = o.Destination,
+                                    LineID = o.LineID,
+                                })
+                            };
+                            accumulatedOptions.Clear();
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -171,12 +171,16 @@
                 exportFormat.Argument.SetDefaultValue("csv");
                 extractCommand.AddOption(exportFormat);
 
+                var columns = new Option<string[]>("--columns", "The desired columns in the exported table of strings.");
+                columns.Argument.SetDefaultValue(new string[] { "character", "text", "id", });
+                extractCommand.AddOption(columns);
+
                 var defaultCharacterName = new Option<string>("--default-name", "The default character name to use. Defaults to none.");
                 defaultCharacterName.Argument.SetDefaultValue(null);
                 extractCommand.AddOption(defaultCharacterName);
             }
 
-            extractCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create<FileInfo[], string, string>(ExtractStrings);
+            extractCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create<FileInfo[], string, string[], string>(ExtractStrings);
 
             // Create a root command with our subcommands
             var rootCommand = new RootCommand
@@ -748,7 +752,7 @@
             }
         }
 
-        private static void ExtractStrings(FileInfo[] inputs, string format, string defaultName = null)
+        private static void ExtractStrings(FileInfo[] inputs, string format, string[] columns, string defaultName = null)
         {
             var compiledResults = CompileProgram(inputs);
 
@@ -761,6 +765,28 @@
             {
                 Log.Error($"Aborting string extraction due to errors");
                 return;
+            }
+
+            if (columns.Length > 0)
+            {
+                bool hasID = false;
+                bool hasText = false;
+                foreach (var column in columns)
+                {
+                    if (column.ToLower().Equals("id"))
+                    {
+                        hasID = true;
+                    }
+                    else if (column.ToLower().Equals("text"))
+                    {
+                        hasText = true;
+                    }
+                }
+                if (!(hasID && hasText))
+                {
+                    Log.Error("Export requires at least an \"id\" and \"text\" column, aborting.");
+                    return;
+                }
             }
 
             // contains every character we have encountered so far
@@ -786,7 +812,8 @@
                     text = line.text.Substring(index + 1).TrimStart();
                     characters.Add(character);
                 }
-                else if (defaultName != null) {
+                else if (defaultName != null)
+                {
                     character = defaultName;
                     characters.Add(character);
                 }
@@ -916,9 +943,12 @@
                         var configuration = new CsvHelper.Configuration.Configuration(System.Globalization.CultureInfo.InvariantCulture);
 
                         var csv = new CsvHelper.CsvWriter(writer, configuration);
-                        csv.WriteField("character");
-                        csv.WriteField("text");
-                        csv.WriteField("id");
+                        
+                        // writing out the headers of the table
+                        foreach (var column in columns)
+                        {
+                            csv.WriteField(column);
+                        }
                         csv.NextRecord();
 
                         foreach (var lines in lineBlocks)
@@ -926,16 +956,41 @@
                             foreach (var line in lines)
                             {
                                 var character = line.character == string.Empty ? "NO CHAR" : line.character;
-                                csv.WriteField(character);
-                                csv.WriteField(line.text);
-                                csv.WriteField(line.id);
+
+                                foreach (var column in columns)
+                                {
+                                    switch (column.ToLower())
+                                    {
+                                        case "id":
+                                        {
+                                            csv.WriteField(line.id);
+                                            break;
+                                        }
+                                        case "text":
+                                        {
+                                            csv.WriteField(line.text);
+                                            break;
+                                        }
+                                        case "character":
+                                        {
+                                            csv.WriteField(character);
+                                            break;
+                                        }
+                                        default:
+                                        {
+                                            csv.WriteField(string.Empty);
+                                            break;
+                                        }
+                                    }
+                                }
 
                                 csv.NextRecord();
-                            }
+                            }   
                             // hack to draw a line after each block
-                            csv.WriteField("---");
-                            csv.WriteField("---");
-                            csv.WriteField("---");
+                            for (int i = 0; i < columns.Length; i++)
+                            {
+                                csv.WriteField(string.Empty);
+                            }
                             csv.NextRecord();
                         }
                     }
@@ -949,26 +1004,28 @@
                     int i = 1;
 
                     // Create the header
-                    sheet.Cell($"A{i}").Value = "Character";
-                    sheet.Cell($"B{i}").Value = "Line";
-                    sheet.Cell($"C{i}").Value = "Line ID";
-                    sheet.Row(i).Style.Font.Bold = true;
+                    for (int j = 0; j < columns.Length; j++)
+                    {
+                        sheet.Cell(i, j + 1).Value = columns[j];
+                    }
+
+                    sheet.Row(i).Style.Font.Bold = true; 
                     sheet.Row(i).Style.Fill.BackgroundColor = XLColor.DarkGray;
                     sheet.Row(i).Style.Font.FontColor = XLColor.White;
                     sheet.SheetView.FreezeRows(1);
 
-                    // The first column (containing the character name) has a
-                    // border on the right hand side
+                    // The first column has a border on the right hand side
                     sheet.Column("A").Style.Border.SetRightBorder(XLBorderStyleValues.Thick);
                     sheet.Column("A").Style.Border.SetRightBorderColor(XLColor.Black);
 
-                    // The second column (containing the line) is indent
-                    // slightly so that it's not hard up against the border
+                    // The second column is indent slightly so that it's 
+                    // not hard up against the border
                     sheet.Column("B").Style.Alignment.Indent = 5;
 
                     // The columns always contain text (don't try to infer it to
                     // be any other type, like numbers or currency)
-                    foreach (var col in sheet.Columns("A:C")) {
+                    foreach (var col in sheet.Columns())
+                    {
                         col.DataType = XLDataType.Text;
                         col.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Left;
                     }
@@ -980,15 +1037,38 @@
                         foreach (var line in lines)
                         {
                             var character = line.character == string.Empty ? "NO CHAR" : line.character;
-                            sheet.Cell($"A{i}").Value = character;
-                            sheet.Cell($"B{i}").Value = line.text;
-                            sheet.Cell($"C{i}").Value = line.id;
+
+                            int j = 1;
+
+                            foreach (var column in columns)
+                            {
+                                string lineValue;
+
+                                switch (column.ToLower())
+                                {
+                                    case "id":
+                                        lineValue = line.id;
+                                        break;
+                                    case "text":
+                                        lineValue = line.text;
+                                        break;
+                                    case "character":
+                                        lineValue = character;
+                                        break;
+                                    default:
+                                        lineValue = string.Empty;
+                                        break;
+                                }
+                                sheet.Cell(i, j).Value = lineValue;
+                                j += 1;
+                            }
+
                             i += 1;
                         }
 
                         // Add the dividing line between this block and the next
-                        sheet.Row(i-1).Style.Border.SetBottomBorder(XLBorderStyleValues.Thick);
-                        sheet.Row(i-1).Style.Border.SetBottomBorderColor(XLColor.Black);
+                        sheet.Row(i - 1).Style.Border.SetBottomBorder(XLBorderStyleValues.Thick);
+                        sheet.Row(i - 1).Style.Border.SetBottomBorderColor(XLColor.Black);
 
                         // The next row is twice as high, to create some visual
                         // space between the block we're ending and the next
@@ -1004,8 +1084,15 @@
 
                     // Wrap the column containing lines, and set it to a
                     // sensible initial width
-                    sheet.Column("B").Style.Alignment.WrapText = true;
-                    sheet.Column("B").Width = 80;
+                    for (int j = 0; j < columns.Length; j++)
+                    {
+                        if (columns[j].ToLower().Equals("text"))
+                        {
+                            sheet.Column(j + 1).Style.Alignment.WrapText = true;
+                            sheet.Column(j + 1).Width = 80;
+                            break;
+                        }
+                    }
 
                     // colouring every character
                     // we do this by moving around the hue wheel and a 20-40% saturation

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -178,9 +178,13 @@
                 var defaultCharacterName = new Option<string>("--default-name", "The default character name to use. Defaults to none.");
                 defaultCharacterName.Argument.SetDefaultValue(null);
                 extractCommand.AddOption(defaultCharacterName);
+
+                var output = new Option<FileInfo>("-o", "File location for saving the extracted strings. Defaults to a file named lines in the current directory");
+                output.AddAlias("--output");
+                extractCommand.AddOption(output);
             }
 
-            extractCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create<FileInfo[], string, string[], string>(ExtractStrings);
+            extractCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create<FileInfo[], string, string[], FileInfo, string>(ExtractStrings);
 
             // Create a root command with our subcommands
             var rootCommand = new RootCommand
@@ -752,7 +756,7 @@
             }
         }
 
-        private static void ExtractStrings(FileInfo[] inputs, string format, string[] columns, string defaultName = null)
+        private static void ExtractStrings(FileInfo[] inputs, string format, string[] columns, FileInfo output, string defaultName = null)
         {
             var compiledResults = CompileProgram(inputs);
 
@@ -787,6 +791,16 @@
                     Log.Error("Export requires at least an \"id\" and \"text\" column, aborting.");
                     return;
                 }
+            }
+
+            string location;
+            if (output == null)
+            {
+                location = $"./lines.{format}";
+            }
+            else
+            {
+                location = output.FullName;
             }
 
             // contains every character we have encountered so far
@@ -937,7 +951,7 @@
             {
                 case "csv":
                 {
-                    using (var writer = new StreamWriter("./lines.csv"))
+                    using (var writer = new StreamWriter(location))
                     {
                         // Use the invariant culture when writing the CSV
                         var configuration = new CsvHelper.Configuration.Configuration(System.Globalization.CultureInfo.InvariantCulture);
@@ -1117,7 +1131,7 @@
                         int q = Convert.ToInt32(value * (1 - f * saturation));
                         int t = Convert.ToInt32(value * (1 - (1 - f) * saturation));
 
-                        switch(hi)
+                        switch (hi)
                         {
                             case 0:
                                 return XLColor.FromArgb(255, v, t, p);
@@ -1134,7 +1148,7 @@
                         }
                     }
 
-                    wb.SaveAs("./lines.xlsx");
+                    wb.SaveAs(location);
                     break;
                 }
             }

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -795,7 +795,7 @@
                         csv.WriteField("id");
                         csv.NextRecord();
 
-                        foreach (var line in lines.OrderBy(x => x.character))
+                        foreach (var line in lines)
                         {
                             var character = line.character == string.Empty ? "NO CHAR" : line.character;
                             csv.WriteField(character);
@@ -815,7 +815,7 @@
                     var wb = new XLWorkbook();
                     var sheet = wb.AddWorksheet("Amazing Dialogue!");
                     int i = 1;
-                    foreach (var line in lines.OrderBy(x => x.character))
+                    foreach (var line in lines)
                     {
                         var character = line.character == string.Empty ? "NO CHAR" : line.character;
                         sheet.Cell($"A{i}").Value = character;

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -1,4 +1,4 @@
-﻿namespace YarnSpinnerConsole
+namespace YarnSpinnerConsole
 {
     using System;
     using System.Collections.Generic;
@@ -170,9 +170,13 @@
                 exportFormat.AddAlias("-f");
                 exportFormat.Argument.SetDefaultValue("csv");
                 extractCommand.AddOption(exportFormat);
+
+                var defaultCharacterName = new Option<string>("--default-name", "The default character name to use. Defaults to none.");
+                defaultCharacterName.Argument.SetDefaultValue(null);
+                extractCommand.AddOption(defaultCharacterName);
             }
 
-            extractCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create<FileInfo[], string>(ExtractStrings);
+            extractCommand.Handler = System.CommandLine.Invocation.CommandHandler.Create<FileInfo[], string, string>(ExtractStrings);
 
             // Create a root command with our subcommands
             var rootCommand = new RootCommand
@@ -744,7 +748,7 @@
             }
         }
 
-        private static void ExtractStrings(FileInfo[] inputs, string format)
+        private static void ExtractStrings(FileInfo[] inputs, string format, string defaultName = null)
         {
             var compiledResults = CompileProgram(inputs);
 
@@ -780,6 +784,10 @@
                 {
                     character = line.text.Substring(0, index);
                     text = line.text.Substring(index + 1).TrimStart();
+                    characters.Add(character);
+                }
+                else if (defaultName != null) {
+                    character = defaultName;
                     characters.Add(character);
                 }
                 else

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -815,13 +815,13 @@
                 }
                 visited.Add(block.Name);
 
-                var zorp = new List<(string id, string text, string character)>();
+                var runOfLines = new List<(string id, string text, string character)>();
 
                 // if we are given an opening line ID we need to add that in at the top
                 // this handles the case where we want options to open the set associated lines
                 if (!string.IsNullOrEmpty(openingLineID))
                 {
-                    zorp.Add(MakeLineData(openingLineID));
+                    runOfLines.Add(MakeLineData(openingLineID));
                 }
 
                 foreach (var content in block.PlayerVisibleContent)
@@ -833,7 +833,7 @@
                         // lines just get added to the current collection of content
                         var line = content as Yarn.Analysis.BasicBlock.LineElement;
 
-                        zorp.Add(MakeLineData(line.LineID));
+                        runOfLines.Add(MakeLineData(line.LineID));
                     }
                     else if (content is Yarn.Analysis.BasicBlock.OptionsElement)
                     {
@@ -841,10 +841,10 @@
                         // an option will always be put into a block by themselves and any child content they have
                         // so this means we close off the current run of content and add it to the overall container
                         // and then make a new one for each option in the option set
-                        if (zorp.Count() > 0)
+                        if (runOfLines.Count() > 0)
                         {
-                            lineBlocks.Add(zorp);
-                            zorp = new List<(string id, string text, string character)>();
+                            lineBlocks.Add(runOfLines);
+                            runOfLines = new List<(string id, string text, string character)>();
                         }
 
                         var options = content as Yarn.Analysis.BasicBlock.OptionsElement;
@@ -862,9 +862,9 @@
                             {
                                 // there is no jump for this option
                                 // we just add it to the collection and continue
-                                zorp.Add(MakeLineData(option.LineID));
-                                lineBlocks.Add(zorp);
-                                zorp = new List<(string id, string text, string character)>();
+                                runOfLines.Add(MakeLineData(option.LineID));
+                                lineBlocks.Add(runOfLines);
+                                runOfLines = new List<(string id, string text, string character)>();
                             }
                         }
 
@@ -886,9 +886,9 @@
                     }
                 }
 
-                if (zorp.Count() > 0)
+                if (runOfLines.Count() > 0)
                 {
-                    lineBlocks.Add(zorp);
+                    lineBlocks.Add(runOfLines);
                 }
             }
 

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -1,4 +1,4 @@
-namespace YarnSpinnerConsole
+﻿namespace YarnSpinnerConsole
 {
     using System;
     using System.Collections.Generic;
@@ -947,6 +947,34 @@ namespace YarnSpinnerConsole
                     var wb = new XLWorkbook();
                     var sheet = wb.AddWorksheet("Amazing Dialogue!");
                     int i = 1;
+
+                    // Create the header
+                    sheet.Cell($"A{i}").Value = "Character";
+                    sheet.Cell($"B{i}").Value = "Line";
+                    sheet.Cell($"C{i}").Value = "Line ID";
+                    sheet.Row(i).Style.Font.Bold = true;
+                    sheet.Row(i).Style.Fill.BackgroundColor = XLColor.DarkGray;
+                    sheet.Row(i).Style.Font.FontColor = XLColor.White;
+                    sheet.SheetView.FreezeRows(1);
+
+                    // The first column (containing the character name) has a
+                    // border on the right hand side
+                    sheet.Column("A").Style.Border.SetRightBorder(XLBorderStyleValues.Thick);
+                    sheet.Column("A").Style.Border.SetRightBorderColor(XLColor.Black);
+
+                    // The second column (containing the line) is indent
+                    // slightly so that it's not hard up against the border
+                    sheet.Column("B").Style.Alignment.Indent = 5;
+
+                    // The columns always contain text (don't try to infer it to
+                    // be any other type, like numbers or currency)
+                    foreach (var col in sheet.Columns("A:C")) {
+                        col.DataType = XLDataType.Text;
+                        col.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Left;
+                    }
+
+                    i += 1;
+
                     foreach (var lines in lineBlocks)
                     {
                         foreach (var line in lines)
@@ -957,11 +985,15 @@ namespace YarnSpinnerConsole
                             sheet.Cell($"C{i}").Value = line.id;
                             i += 1;
                         }
-                        // total hack for now to draw a line after each block
-                        sheet.Cell($"A{i}").Value = "---";
-                        sheet.Cell($"B{i}").Value = "---";
-                        sheet.Cell($"C{i}").Value = "---";
-                        i += 1;
+
+                        // Add the dividing line between this block and the next
+                        sheet.Row(i-1).Style.Border.SetBottomBorder(XLBorderStyleValues.Thick);
+                        sheet.Row(i-1).Style.Border.SetBottomBorderColor(XLColor.Black);
+
+                        // The next row is twice as high, to create some visual
+                        // space between the block we're ending and the next
+                        // one.
+                        sheet.Row(i).Height = sheet.RowHeight * 2;
                     }
 
                     // adding the unnamed character into the list of characters so it will also get a colour
@@ -969,6 +1001,11 @@ namespace YarnSpinnerConsole
                     {
                         characters.Add("NO CHAR");
                     }
+
+                    // Wrap the column containing lines, and set it to a
+                    // sensible initial width
+                    sheet.Column("B").Style.Alignment.WrapText = true;
+                    sheet.Column("B").Width = 80;
 
                     // colouring every character
                     // we do this by moving around the hue wheel and a 20-40% saturation

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -759,8 +759,6 @@
                 return;
             }
 
-            Log.Info($"Exporting strings as a {format}");
-
             // contains every character we have encountered so far
             // this is needed later on for highlighting them
             // also I guess it means we can export info about characters
@@ -815,7 +813,6 @@
                     // we have already visited this one so we can go on without it
                     return;
                 }
-                Log.Info($"We have block: {block.Name}");
                 visited.Add(block.Name);
 
                 var zorp = new List<(string id, string text, string character)>();
@@ -835,7 +832,6 @@
                     {
                         // lines just get added to the current collection of content
                         var line = content as Yarn.Analysis.BasicBlock.LineElement;
-                        Log.Info($"\tIt contains {line.LineID}");
 
                         zorp.Add(MakeLineData(line.LineID));
                     }
@@ -847,7 +843,6 @@
                         // and then make a new one for each option in the option set
                         if (zorp.Count() > 0)
                         {
-                            Log.Info($"Hit an option block, adding the existing {zorp.Count()} content elements before continuing");
                             lineBlocks.Add(zorp);
                             zorp = new List<(string id, string text, string character)>();
                         }
@@ -856,12 +851,9 @@
                         var jumpOptions = new Dictionary<string, Yarn.Analysis.BasicBlock>();
                         foreach (var option in options.Options)
                         {
-                            Log.Info($"\t-> {option.LineID}: {option.Destination}");
-
                             var destination = blocks.First(block => block.LabelName == option.Destination);
                             if (destination != null && destination.PlayerVisibleContent.Count() > 0)
                             {
-                                Log.Info("\t\tand the destination has stuff inside");
                                 // there is a valid jump we need to deal with
                                 // we store this and will handle it later
                                 jumpOptions[option.LineID] = destination;
@@ -890,7 +882,7 @@
                     }
                     else
                     {
-                        Log.Error("\tSomehow encountered a non-user facing element...");
+                        Log.Error("Somehow encountered a non-user facing element...");
                     }
                 }
 
@@ -906,17 +898,11 @@
                 Log.Error($"String table has {compiledResults.StringTable.Count()} lines, we encountered {lineCount}!");
             }
 
-            Log.Info($"We have {characters.Count()} characters in this story");
-            foreach (var character in characters)
-            {
-                Log.Info(character);
-            }
-
             switch (format)
             {
                 case "csv":
                 {
-                    using (var writer = new StreamWriter("./test.csv"))
+                    using (var writer = new StreamWriter("./lines.csv"))
                     {
                         // Use the invariant culture when writing the CSV
                         var configuration = new CsvHelper.Configuration.Configuration(System.Globalization.CultureInfo.InvariantCulture);
@@ -944,8 +930,6 @@
                             csv.WriteField("---");
                             csv.NextRecord();
                         }
-
-                        Log.Info($"Wrote CSV out");
                     }
 
                     break;
@@ -1018,8 +1002,7 @@
                         }
                     }
 
-                    wb.SaveAs("./Test.xlsx");
-                    Log.Info($"Wrote xlslx out");
+                    wb.SaveAs("./lines.xlsx");
                     break;
                 }
             }

--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -375,6 +375,17 @@
         {
             var compiledResults = CompileProgram(inputs);
 
+            foreach (var diagnostic in compiledResults.Diagnostics)
+            {
+                Log.Diagnostic(diagnostic);
+            }
+
+            if (compiledResults.Diagnostics.Any(d => d.Severity == Diagnostic.DiagnosticSeverity.Error))
+            {
+                Log.Error($"Not compiling files because errors were encountered.");
+                return;
+            }
+
             var programOutputPath = Path.Combine(outputDirectory.FullName, outputName);
             var stringTableOutputPath = Path.Combine(outputDirectory.FullName, outputStringTableName);
             var metadataName = Path.GetFileNameWithoutExtension(stringTableOutputPath);

--- a/src/YarnSpinner.Console/ysc.csproj
+++ b/src/YarnSpinner.Console/ysc.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
-    <PackageReference Include="YarnSpinner" Version="2.1.0" />
-    <PackageReference Include="YarnSpinner.Compiler" Version="2.1.0" />
+    <PackageReference Include="YarnSpinner" Version="2.2.0" />
+    <PackageReference Include="YarnSpinner.Compiler" Version="2.2.0" />
     <PackageReference Include="CsvHelper" Version="12.2.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/YarnSpinner.Console/ysc.csproj
+++ b/src/YarnSpinner.Console/ysc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
     <RootNamespace>YarnSpinnerConsole</RootNamespace>
     <UseAppHost>true</UseAppHost>
     <PublishSelfContained>true</PublishSelfContained>
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20253.1" />
     <PackageReference Include="YarnSpinner" Version="2.2.0" />
     <PackageReference Include="YarnSpinner.Compiler" Version="2.2.0" />


### PR DESCRIPTION
This adds in a new subcommand for ysc `extract` that extracts all strings on the input files for the purposes of VO recording.
This allows exporting in two formats, csv and xlsx with various levels of customisation, full details of the subcommand are in the readme.