### PR TITLE
Ensure that existing yarnc file is truncated when overwriting

### DIFF
--- a/src/YarnSpinner.Console/Commands/CompileCommand.cs
+++ b/src/YarnSpinner.Console/Commands/CompileCommand.cs
@@ -10,7 +10,8 @@ namespace YarnSpinnerConsole
         {
             var compiledResults = YarnSpinnerConsole.CompileProgram(inputs);
 
-            if (stdout) {
+            if (stdout)
+            {
                 EmitCompilationResult(compiledResults, System.Console.Out);
                 return;
             }
@@ -46,7 +47,7 @@ namespace YarnSpinnerConsole
             var stringTableOutputPath = Path.Combine(outputDirectory.FullName, outputStringTableName);
             var stringMetadatOutputPath = Path.Combine(outputDirectory.FullName, outputMetadataTableName);
 
-            using (var outStream = new FileStream(programOutputPath, FileMode.OpenOrCreate))
+            using (var outStream = new FileStream(programOutputPath, FileMode.Create))
             using (var codedStream = new Google.Protobuf.CodedOutputStream(outStream))
             {
                 compiledResults.Program.WriteTo(codedStream);
@@ -121,14 +122,16 @@ namespace YarnSpinnerConsole
             var compilerOutput = new Yarn.CompilerOutput();
             compilerOutput.Program = program;
 
-            foreach (var entry in compiledResults.StringTable) {
+            foreach (var entry in compiledResults.StringTable)
+            {
                 var tableEntry = new Yarn.StringInfo();
                 tableEntry.Text = entry.Value.text;
 
                 compilerOutput.Strings.Add(entry.Key, tableEntry);
             }
 
-            foreach (var diagnostic in compiledResults.Diagnostics) {
+            foreach (var diagnostic in compiledResults.Diagnostics)
+            {
                 var diag = new Yarn.Diagnostic();
                 diag.Message = diagnostic.Message;
                 diag.FileName = diagnostic.FileName;


### PR DESCRIPTION
I'm currently tinkering on a Rust interpreter for Yarn, and I ran into a pretty subtle bug with `ysc`'s compiled output while testing (which I thought was my code's fault all day 😅).

If the compiler overwrites an existing `yarnc` file, and the new output is shorter than the old output, some of the old data gets left in the file, causing it to no longer parse correctly. This probably isn't something that *users* of Yarn run into that often, as scripts will generally get bigger over time.

I was able to fix this by setting the file mode to `Create` instead of `OpenOrCreate` (which, contrary to what the name would suggest, still works if the file already exists - it just truncates any existing data before writing).