### PR TITLE
better output codes on compile errors

### DIFF
--- a/src/YarnSpinner.Console/Commands/CompileCommand.cs
+++ b/src/YarnSpinner.Console/Commands/CompileCommand.cs
@@ -10,12 +10,6 @@ namespace YarnSpinnerConsole
         {
             var compiledResults = YarnSpinnerConsole.CompileProgram(inputs);
 
-            if (stdout)
-            {
-                EmitCompilationResult(compiledResults, System.Console.Out);
-                return;
-            }
-
             foreach (var diagnostic in compiledResults.Diagnostics)
             {
                 Log.Diagnostic(diagnostic);
@@ -24,6 +18,13 @@ namespace YarnSpinnerConsole
             if (compiledResults.Diagnostics.Any(d => d.Severity == Diagnostic.DiagnosticSeverity.Error))
             {
                 Log.Error($"Not compiling files because errors were encountered.");
+                System.Environment.Exit(1);
+                return;
+            }
+
+            if (stdout)
+            {
+                EmitCompilationResult(compiledResults, System.Console.Out);
                 return;
             }
 


### PR DESCRIPTION
Made it so that compile errors would successfully emit a non-zero output code. Additionally, I moved the `stdout` check a bit farther down in the file so that errors from `stdout` compilation would be identical to non-stdout compilation, since the flags relevance should only matter if program files *can* be made.

I'm not very familiar with C#, so I had some trouble making this simple PR. I attempted to throw an exception in the CompileCommand.cs file, so that the code in Main could handle the exception as it handles everything else, but it then appeared to not be handled? It might have something to do with async processes, but once I realized that I could just exit in that file, I decided to try that simpler approach!