### PR TITLE
use BuiltInTypes to fix error in YarnSpinnerConsole.cs

### DIFF
--- a/src/YarnSpinner.Console/YarnSpinnerConsole.cs
+++ b/src/YarnSpinner.Console/YarnSpinnerConsole.cs
@@ -282,8 +282,8 @@
                 .WithName("visited")
                 .WithType(
                     new FunctionTypeBuilder()
-                        .WithParameter(Yarn.Types.String)
-                        .WithReturnType(Yarn.Types.Boolean)
+                        .WithParameter(Yarn.BuiltinTypes.String)
+                        .WithReturnType(Yarn.BuiltinTypes.Boolean)
                         .FunctionType)
                 .Declaration;
 
@@ -291,8 +291,8 @@
                 .WithName("visited_count")
                 .WithType(
                     new FunctionTypeBuilder()
-                        .WithParameter(Yarn.Types.String)
-                        .WithReturnType(Yarn.Types.Number)
+                        .WithParameter(Yarn.BuiltinTypes.String)
+                        .WithReturnType(Yarn.BuiltinTypes.Number)
                         .FunctionType)
                 .Declaration;
 


### PR DESCRIPTION
This was failing to compile for me and [seemingly in the CI](https://github.com/YarnSpinnerTool/YarnSpinner-Console/actions/runs/6281714262/job/17060416449) for this project 

Hopefully this is the correct fix. I was able to run the project locally after this change 

